### PR TITLE
Better environment variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To deploy the system to your own discord server, follow the standard Discord dev
 ### Prerequisites
 
 1. You must have Python 3.6 or higher installed. You can get it from the [official website][4].
-2. You must provide a Discord token - either through an environment variable `DOF_TOKEN` or by creating the `token.txt`
+2. You must provide a Discord token - either through an environment variable `DOF_TOKEN` or by creating the `token`
 file in `res` directory - for more information following the instructions when attempting to run the bot without the
 token.
 3. You must either install the package (see below) or make sure to install all dependencies (see `setup.py`).

--- a/dof_discord_bot/src/constants.py
+++ b/dof_discord_bot/src/constants.py
@@ -19,12 +19,12 @@ TESTS_DIR = _os.path.join(ROOT_DIR, "tests")
 # Retrieve the token - either it will be an environment variable, or will be in the text file
 TOKEN = _os.getenv("DOF_TOKEN", "")
 if not TOKEN:
-    if _os.path.exists(_os.path.join(RES_DIR, "token.txt")):
-        with open(_os.path.join(RES_DIR, "token.txt")) as f:
+    if _os.path.exists(_os.path.join(RES_DIR, "token")):
+        with open(_os.path.join(RES_DIR, "token")) as f:
             TOKEN = f.read().strip()
     else:
         print(f"Missing token - either declare \"DOF_TOKEN\" environment variable or include the token in the "
-              f"\"token.txt\" file at \"{_os.path.join(RES_DIR, 'token.txt')}\"", file=_sys.stderr)
+              f"\"token\" file at \"{_os.path.join(RES_DIR, 'token')}\"", file=_sys.stderr)
         exit(1)
 
 # Declare the command prefix - each command must have this prefix in front in order to be considered a command

--- a/dof_discord_bot/src/constants.py
+++ b/dof_discord_bot/src/constants.py
@@ -3,6 +3,7 @@ Constants and other static values.
 """
 import os as _os
 import sys as _sys
+import dotenv as _dotenv
 
 # Declare path to the root folder (dof-discord-bot)
 ROOT_DIR = _os.path.normpath(_os.path.join(_os.path.dirname(__file__), "..", ".."))
@@ -15,6 +16,9 @@ SRC_DIR = _os.path.join(DOF_DISCORD_BOT_DIR, "src")
 LOG_DIR = _os.path.join(DOF_DISCORD_BOT_DIR, "log")
 RES_DIR = _os.path.join(DOF_DISCORD_BOT_DIR, "res")
 TESTS_DIR = _os.path.join(ROOT_DIR, "tests")
+
+# Load environment variables
+_dotenv.load_dotenv(_os.path.join(DOF_DISCORD_BOT_DIR, ".env"))
 
 # Retrieve the token - either it will be an environment variable, or will be in the text file
 TOKEN = _os.getenv("DOF_TOKEN", "")

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(
     ],
     install_requires=[
         "discord",
-        "pyyaml"
+        "pyyaml",
+        "python-dotenv"
     ],
     python_requires=">=3.6",
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,8 @@ On top of the standard requirements for running `dof-discord-bot`, you must also
 
 1. Install [`pytest`][1] and the [`pytest-cov`][2] plugin for code coverage.
 2. Set `DOF_TESTING_TOKEN` environment variable, which will be used to load a secondary bot used to simulate a real user
-and perform integration tests.
+and perform integration tests. You can also provide a `token-testing` file with the token - it should be located in the
+package's resources folder, similarly to where the actual bot's token can be placed.
 
 ### Usage
 

--- a/tests/integration_tests/helpers.py
+++ b/tests/integration_tests/helpers.py
@@ -20,15 +20,21 @@ from dof_discord_bot.src.bot import Bot as _Bot  # noqa
 from dof_discord_bot.src.constants import COMMAND_PREFIX as _PREFIX, TOKEN as _DOF_BOT_TOKEN  # noqa
 from dof_discord_bot.src.logger import Log as _Log  # noqa
 
-# Find the testing bot token in the environment
-_TESTING_BOT_TOKEN = _os.getenv("DOF_TESTING_TOKEN", "")
-if not _TESTING_BOT_TOKEN:
-    _pytest.exit(f"Missing token - please declare \"DOF_TESTING_TOKEN\" environment variable")
-
 # Declare some useful directories
 TESTS_DIR = _os.path.join(_os.path.dirname(__file__), "..")
 INTEGRATION_TESTS_DIR = _os.path.join(TESTS_DIR, "integration_tests")
 LOG_DIR = _os.path.join(TESTS_DIR, "log")
+RES_DIR = _os.path.join(TESTS_DIR, "..", "dof_discord_bot", "res")
+
+# Find the testing bot token in the environment
+_TESTING_BOT_TOKEN = _os.getenv("DOF_TESTING_TOKEN", "")
+if not _TESTING_BOT_TOKEN:
+    if _os.path.exists(_os.path.join(RES_DIR, "token-testing")):
+        with open(_os.path.join(RES_DIR, "token-testing")) as f:
+            _TESTING_BOT_TOKEN = f.read().strip()
+    else:
+        _pytest.exit(f"Missing token - either declare \"DOF_TESTING_TOKEN\" environment variable or include the token "
+                     f"in the \"token-testing\" file at \"{_os.path.join(RES_DIR, 'token-testing')}\"")
 
 # Generate the testing channel name
 _TEST_CHANNEL_NAME = "test-" + "".join(_random.choice(_string.ascii_lowercase) for _ in range(16))

--- a/tests/integration_tests/helpers.py
+++ b/tests/integration_tests/helpers.py
@@ -17,24 +17,23 @@ from discord.ext import commands as _commands
 # Make sure dof_discord_bot package can be found and overrides any installed versions
 _sys.path.insert(0, _os.path.join(_os.path.dirname(__file__), "..", ".."))
 from dof_discord_bot.src.bot import Bot as _Bot  # noqa
-from dof_discord_bot.src.constants import COMMAND_PREFIX as _PREFIX, TOKEN as _DOF_BOT_TOKEN  # noqa
+from dof_discord_bot.src.constants import COMMAND_PREFIX as _PREFIX, TOKEN as _DOF_BOT_TOKEN, RES_DIR as _RES_DIR  # noqa
 from dof_discord_bot.src.logger import Log as _Log  # noqa
 
 # Declare some useful directories
 TESTS_DIR = _os.path.join(_os.path.dirname(__file__), "..")
 INTEGRATION_TESTS_DIR = _os.path.join(TESTS_DIR, "integration_tests")
 LOG_DIR = _os.path.join(TESTS_DIR, "log")
-RES_DIR = _os.path.join(TESTS_DIR, "..", "dof_discord_bot", "res")
 
 # Find the testing bot token in the environment
 _TESTING_BOT_TOKEN = _os.getenv("DOF_TESTING_TOKEN", "")
 if not _TESTING_BOT_TOKEN:
-    if _os.path.exists(_os.path.join(RES_DIR, "token-testing")):
-        with open(_os.path.join(RES_DIR, "token-testing")) as f:
+    if _os.path.exists(_os.path.join(_RES_DIR, "token-testing")):
+        with open(_os.path.join(_RES_DIR, "token-testing")) as f:
             _TESTING_BOT_TOKEN = f.read().strip()
     else:
         _pytest.exit(f"Missing token - either declare \"DOF_TESTING_TOKEN\" environment variable or include the token "
-                     f"in the \"token-testing\" file at \"{_os.path.join(RES_DIR, 'token-testing')}\"")
+                     f"in the \"token-testing\" file at \"{_os.path.join(_RES_DIR, 'token-testing')}\"")
 
 # Generate the testing channel name
 _TEST_CHANNEL_NAME = "test-" + "".join(_random.choice(_string.ascii_lowercase) for _ in range(16))


### PR DESCRIPTION
Added `.env` file support, file-based token support for the testing bot, and fixed the token filenames to *not* include Windows-specific `.txt` file extension.